### PR TITLE
Just ran some testcases.

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -58,7 +58,7 @@ func (server *Server) Run() {
 
 func (client *Client) handleRequest() {
 	reader := bufio.NewReader(client.conn)
-	header, err := reader.ReadBytes(byte(13))
+	header, _ := reader.ReadBytes(byte(13))
 	if len(header) < 1 {
 		return
 	}


### PR DESCRIPTION
After running `staticcheck`, got:
    _relay.go:61:2: this value of err is never used (SA4006)_
and replace unused error with a `_`.